### PR TITLE
Fix auto-deploy pipeline for all workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,7 +30,7 @@ jobs:
             git checkout main
             git reset --hard origin/main
 
-            if git merge --no-ff ${{ github.sha }} -m "Auto-merge ${GITHUB_REF_NAME} into main [skip ci]"; then
+            if git merge --no-ff ${{ github.sha }} -m "Auto-merge ${GITHUB_REF_NAME} into main"; then
               if git push origin main; then
                 echo "Merge and push succeeded on attempt $attempt"
                 exit 0
@@ -51,3 +51,26 @@ jobs:
       - name: Delete merged branch
         if: success()
         run: git push origin --delete "${{ github.ref_name }}" || true
+
+  deploy:
+    needs: merge-to-main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Netlify
+        run: npx netlify-cli deploy --prod --dir=dist
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -45,6 +45,19 @@ jobs:
             7. Commit your changes with a descriptive message referencing #${{ github.event.issue.number }}
             8. Push directly to main
 
+      - name: Ensure changes are on main
+        run: |
+          git fetch origin main
+          # Check if HEAD is ahead of main (Claude pushed to a branch instead of main)
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout main
+            git reset --hard origin/main
+            git merge --no-ff HEAD@{1} -m "Auto-merge issue #${{ github.event.issue.number }} into main"
+            git push origin main
+          fi
+
       - name: Close issue
         uses: actions/github-script@v7
         with:
@@ -60,5 +73,28 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: 'Implemented and pushed to main.',
+              body: 'Implemented and deployed to main.',
             });
+
+  deploy:
+    needs: implement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Netlify
+        run: npx netlify-cli deploy --prod --dir=dist
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
GITHUB_TOKEN pushes don't trigger other workflows (GitHub's anti-recursion). This broke the chain: issue workflow → auto-merge → deploy.

Fixes:
- auto-merge.yml: remove [skip ci], add inline deploy job
- issue-to-pr.yml: ensure code lands on main, add inline deploy job

Each workflow is now self-contained: it merges and deploys without relying on triggering another workflow.

https://claude.ai/code/session_0164mgqubWSweTQvVMSxsiqa