### PR TITLE
QW-4: Add print-optimized layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -389,7 +389,7 @@ const App: React.FC = () => {
 
       {/* Skeleton / shimmer loading overlay */}
       {loading && (
-        <div data-testid="loading-overlay" className="absolute inset-0 z-50 flex items-center justify-center bg-white/80 dark:bg-surface-950/80 backdrop-blur-sm">
+        <div data-testid="loading-overlay" className="absolute inset-0 z-50 flex items-center justify-center bg-white/80 dark:bg-surface-950/80 backdrop-blur-sm print-hide">
           <div className="text-center space-y-4">
             {/* Shimmer placeholder blocks */}
             <div className="flex flex-col items-center gap-3">
@@ -407,7 +407,7 @@ const App: React.FC = () => {
       {error && <ErrorBanner message={error} onRetry={retry} />}
 
       {/* Brand mark — double-click to reset view, hidden on mobile to avoid overlap */}
-      <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 hidden md:block">
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 hidden md:block print-hide">
         <button
           onClick={handleResetView}
           className="cursor-pointer bg-transparent border-none"
@@ -420,7 +420,7 @@ const App: React.FC = () => {
       </div>
 
       {/* Top-right controls — dropdown menus and draw tool */}
-      <div className="absolute top-3 md:top-4 right-3 md:right-[17rem] z-10 flex items-center gap-2">
+      <div className="absolute top-3 md:top-4 right-3 md:right-[17rem] z-10 flex items-center gap-2 print-hide">
         <DrawTool
           active={drawMode}
           hasPolygon={!!drawnPolygon}
@@ -449,7 +449,9 @@ const App: React.FC = () => {
       </div>
 
       {/* Search */}
-      <SearchBar data={data} onSelect={handleSearch} recent={recent} />
+      <div className="print-hide">
+        <SearchBar data={data} onSelect={handleSearch} recent={recent} />
+      </div>
 
       {/* Ranking table */}
       {showRanking && (
@@ -482,12 +484,14 @@ const App: React.FC = () => {
       )}
 
       {/* Layer selector */}
-      <LayerSelector
-        activeLayer={activeLayer}
-        onLayerChange={setActiveLayer}
-        onCustomizeQuality={handleToggleCustomQuality}
-        isCustomWeights={isCustomWeights(qualityWeights)}
-      />
+      <div className="print-hide">
+        <LayerSelector
+          activeLayer={activeLayer}
+          onLayerChange={setActiveLayer}
+          onCustomizeQuality={handleToggleCustomQuality}
+          isCustomWeights={isCustomWeights(qualityWeights)}
+        />
+      </div>
 
       {/* Legend — repositioned for mobile */}
       <Legend layerId={activeLayer} colorblind={colorblind} />
@@ -574,7 +578,7 @@ const App: React.FC = () => {
       {/* CF-6: Draw mode hint */}
       {drawMode && (
         <div className="absolute bottom-20 md:bottom-8 left-1/2 -translate-x-1/2 z-10 px-4 py-2 rounded-xl
-                       bg-violet-500/90 text-white text-xs font-medium backdrop-blur-sm shadow-lg">
+                       bg-violet-500/90 text-white text-xs font-medium backdrop-blur-sm shadow-lg print-hide">
           {t('draw.hint')}
         </div>
       )}
@@ -582,13 +586,13 @@ const App: React.FC = () => {
       {/* IN-6: Offline indicator */}
       {isOffline && (
         <div className="absolute top-12 left-1/2 -translate-x-1/2 z-50 px-3 py-1.5 rounded-lg
-                       bg-amber-500/90 text-white text-xs font-medium backdrop-blur-sm">
+                       bg-amber-500/90 text-white text-xs font-medium backdrop-blur-sm print-hide">
           {t('offline.indicator')}
         </div>
       )}
 
       {/* Attribution footer */}
-      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 hidden md:block">
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 hidden md:block print-hide">
         <p className="text-[10px] text-surface-600/70 dark:text-surface-500/70">{t('footer.attribution')}</p>
       </div>
 

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -16,7 +16,7 @@ export const Legend: React.FC<LegendProps> = React.memo(({ layerId, colorblind: 
   const tickIndices = [0, n - 1];
 
   return (
-    <div className="fixed md:absolute bottom-5 md:bottom-8 left-3 md:left-4 z-10">
+    <div className="fixed md:absolute bottom-5 md:bottom-8 left-3 md:left-4 z-10 print-legend">
       <div className="rounded-xl bg-white/90 dark:bg-surface-900/90 backdrop-blur-md border border-surface-200 dark:border-surface-700/40 shadow-2xl px-4 py-3">
         <div className="text-xs font-semibold text-surface-500 dark:text-surface-400 uppercase tracking-wider mb-2">
           {t(layer.labelKey)}

--- a/src/components/NeighborhoodPanel.tsx
+++ b/src/components/NeighborhoodPanel.tsx
@@ -275,6 +275,18 @@ export const NeighborhoodPanel: React.FC<PanelProps> = ({ data: d, metroAverages
         </svg>
         {t('share.image')}
       </button>
+      {/* QW-4: Print button */}
+      <button
+        onClick={() => window.print()}
+        className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg text-xs font-medium min-h-[44px] md:min-h-0
+                   bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-300
+                   hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors print-hide-btn"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+        </svg>
+        {t('export.print')}
+      </button>
     </div>
   );
 
@@ -764,7 +776,7 @@ export const NeighborhoodPanel: React.FC<PanelProps> = ({ data: d, metroAverages
     <>
       {/* Desktop: side panel */}
       <div className="hidden md:block absolute top-0 left-0 z-20 h-full w-[380px] max-w-[90vw] overflow-y-auto
-                      bg-white/95 dark:bg-surface-950/95 backdrop-blur-xl border-r border-surface-200 dark:border-surface-800/50 shadow-2xl">
+                      bg-white/95 dark:bg-surface-950/95 backdrop-blur-xl border-r border-surface-200 dark:border-surface-800/50 shadow-2xl print-panel">
         {/* Header */}
         <div className="sticky top-0 bg-white/95 dark:bg-surface-950/95 backdrop-blur-xl border-b border-surface-200 dark:border-surface-800/50 px-6 py-5">
           <div className="flex items-start justify-between">
@@ -816,7 +828,7 @@ export const NeighborhoodPanel: React.FC<PanelProps> = ({ data: d, metroAverages
         className="md:hidden fixed bottom-0 left-0 right-0 z-20
                    bg-white/95 dark:bg-surface-950/95 backdrop-blur-xl
                    border-t border-surface-200 dark:border-surface-800/50
-                   shadow-[0_-4px_30px_rgba(0,0,0,0.15)] rounded-t-2xl"
+                   shadow-[0_-4px_30px_rgba(0,0,0,0.15)] rounded-t-2xl print-hide"
         style={{
           height: sheetHeight,
           transition: isDragging ? 'none' : 'height 0.3s cubic-bezier(0.25, 1, 0.5, 1)',

--- a/src/index.css
+++ b/src/index.css
@@ -136,39 +136,71 @@ body,
   }
 }
 
-/* QW-4: Print mode — show only map + legend */
+/* QW-4: Print-optimized layout */
 @media print {
   body, html, #root {
     overflow: visible !important;
     height: auto !important;
+    width: 100% !important;
   }
 
-  /* Hide everything except the map and legend */
-  .absolute:not([data-print="keep"]),
-  .fixed {
+  /* Hide UI chrome: search, toolbars, layer selector, floating controls, tooltips */
+  .print-hide {
     display: none !important;
-  }
-
-  /* Keep the map container visible */
-  div[class*="absolute inset-0"] {
-    display: block !important;
-    position: relative !important;
-    width: 100vw !important;
-    height: 100vh !important;
-  }
-
-  /* Keep the legend visible */
-  .print-keep {
-    display: block !important;
-    position: fixed !important;
-    bottom: 20px !important;
-    left: 20px !important;
-    z-index: 10 !important;
   }
 
   /* Hide map controls in print */
   .maplibregl-ctrl-group,
   .maplibregl-ctrl-attrib {
     display: none !important;
+  }
+
+  /* Map: expand to fill available width, fixed height for the print page */
+  .print-map {
+    position: relative !important;
+    width: 100% !important;
+    height: 60vh !important;
+  }
+
+  /* Neighborhood panel: print-friendly layout beside/below map */
+  .print-panel {
+    position: relative !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+    overflow: visible !important;
+    box-shadow: none !important;
+    border: none !important;
+    background: white !important;
+    backdrop-filter: none !important;
+    page-break-inside: avoid;
+  }
+
+  .print-panel * {
+    color-adjust: exact !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  /* Legend: inline, no fixed positioning */
+  .print-legend {
+    position: relative !important;
+    display: block !important;
+    margin: 8px 0 !important;
+    box-shadow: none !important;
+  }
+
+  /* Hide print buttons and close buttons inside the panel */
+  .print-panel button[title],
+  .print-panel .print-hide-btn {
+    display: none !important;
+  }
+
+  /* Force light backgrounds for readability */
+  .dark .print-panel {
+    background: white !important;
+  }
+  .dark .print-panel * {
+    color: #1e293b !important;
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,6 +158,7 @@
   "map.reset_view": "Back to overview",
   "export.csv": "Export CSV",
   "export.pdf": "Export PDF",
+  "export.print": "Print",
   "export.field": "Field",
   "export.value": "Value",
   "footer.attribution": "Data: Statistics Finland, HSL, HSY, Police, Kela, THL, Tax Admin, Traficom, Min. of Justice, OpenStreetMap (CC BY 4.0)",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -158,6 +158,7 @@
   "map.reset_view": "Palaa yleiskuvaan",
   "export.csv": "Lataa CSV",
   "export.pdf": "Lataa PDF",
+  "export.print": "Tulosta",
   "export.field": "Kentt\u00e4",
   "export.value": "Arvo",
   "footer.attribution": "Aineisto: Tilastokeskus, HSL, HSY, Poliisi, Kela, THL, Verohallinto, Traficom, Oikeusministeriö, OpenStreetMap (CC BY 4.0)",


### PR DESCRIPTION
## Summary
- Add `@media print` CSS rules that hide UI chrome (search bar, layer selector, toolbar, floating controls, mobile bottom sheet, draw hints, offline indicator)
- NeighborhoodPanel renders in a print-friendly full-width layout with forced light backgrounds for readability
- Legend displays inline (no fixed positioning) in print mode
- Add a "Print" button alongside existing CSV/PDF/Image export buttons in NeighborhoodPanel

## Test plan
- [ ] Open a neighborhood panel, click "Print" button, verify browser print dialog opens
- [ ] In print preview, confirm: no search bar, no layer selector, no toolbar controls, no map zoom controls
- [ ] Confirm the neighborhood panel content and legend are visible in print preview
- [ ] Verify dark mode prints with light backgrounds for readability
- [ ] All 617 existing tests pass, lint clean, build succeeds

https://claude.ai/code/session_01HX3dCSXotBGDPmeiaZqJw3