### PR TITLE
Add visual regression tests for key visual states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,21 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: E2E tests
-        run: npm run test:e2e
+        run: npx playwright test --project=e2e
+
+      - name: Visual regression tests
+        run: npm run test:visual
+
+      - name: Upload visual diff artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-diffs
+          path: |
+            test-results/
+            e2e/visual/visual-regression.spec.ts-snapshots/*-diff.png
+            e2e/visual/visual-regression.spec.ts-snapshots/*-actual.png
+          retention-days: 14
 
       - name: Check bundle size (IN-3)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 test-results/
+playwright-report/

--- a/e2e/visual/visual-regression.spec.ts
+++ b/e2e/visual/visual-regression.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForDataLoaded(page: import('@playwright/test').Page) {
+  await page.waitForSelector('[data-testid="app-root"][data-loaded="true"]', { timeout: 30000 });
+}
+
+/** Wait for map tiles to settle — the canvas keeps painting while tiles stream in. */
+async function waitForMapIdle(page: import('@playwright/test').Page) {
+  await page.waitForSelector('.maplibregl-canvas', { timeout: 15000 });
+  // Allow map tiles and choropleth paint to finish
+  await page.waitForTimeout(2000);
+}
+
+test.describe('visual regression', () => {
+  test.describe.configure({ retries: 0 });
+
+  test('default map load', async ({ page }) => {
+    await page.goto('/');
+    await waitForDataLoaded(page);
+    await waitForMapIdle(page);
+
+    await expect(page).toHaveScreenshot('default-map-load.png', {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+
+  test('dark mode', async ({ page }) => {
+    await page.goto('/');
+    await waitForDataLoaded(page);
+    await waitForMapIdle(page);
+
+    // Open settings dropdown and switch to dark mode
+    const settingsButton = page.locator(`button[aria-label="${await getSettingsLabel(page)}"]`);
+    await settingsButton.click();
+
+    // Click the dark mode button (moon icon — third theme button)
+    const darkButton = page.locator('button[title="Tumma"], button[title="Dark"]').first();
+    await darkButton.click();
+
+    // Close dropdown by clicking elsewhere
+    await page.locator('.maplibregl-canvas').click({ position: { x: 10, y: 10 } });
+    await page.waitForTimeout(500);
+
+    // Verify dark class is applied
+    const htmlClass = await page.locator('html').getAttribute('class');
+    expect(htmlClass).toContain('dark');
+
+    await waitForMapIdle(page);
+
+    await expect(page).toHaveScreenshot('dark-mode.png', {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+
+  test('neighborhood panel open', async ({ page }) => {
+    await page.goto('/#pno=00100&layer=quality_index');
+    await waitForDataLoaded(page);
+    await waitForMapIdle(page);
+
+    // Wait for the neighborhood panel to appear (desktop side panel)
+    const panel = page.locator('.hidden.md\\:block.absolute').first();
+    await expect(panel).toBeVisible({ timeout: 10000 });
+
+    // Wait for stats to render
+    await expect(panel.locator('text=Väestö').first()).toBeVisible({ timeout: 5000 });
+
+    await expect(page).toHaveScreenshot('neighborhood-panel-open.png', {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+
+  test('comparison panel with 3 neighborhoods', async ({ page }) => {
+    await page.goto('/#pno=00100&compare=00200,00300&layer=median_income');
+    await waitForDataLoaded(page);
+    await waitForMapIdle(page);
+
+    // Wait for comparison panel
+    const comparisonTitle = page.locator('h2:has-text("Vertailu")').first();
+    await expect(comparisonTitle).toBeVisible({ timeout: 10000 });
+
+    // Ensure table data is rendered
+    const comparisonPanel = page.locator('.hidden.md\\:block.absolute.bottom-4');
+    await expect(comparisonPanel.locator('text=Väestö').first()).toBeVisible({ timeout: 5000 });
+
+    await expect(page).toHaveScreenshot('comparison-panel-3-neighborhoods.png', {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+
+  test('filter panel active', async ({ page }) => {
+    await page.goto('/');
+    await waitForDataLoaded(page);
+    await waitForMapIdle(page);
+
+    // Open tools dropdown
+    const toolsButton = page.locator('button[aria-label="Työkalut"]');
+    await expect(toolsButton).toBeVisible({ timeout: 5000 });
+    await toolsButton.click();
+
+    // Click "Suodata" (Filter)
+    await page.locator('text=Suodata').first().click();
+
+    // Wait for filter panel
+    await expect(page.locator('text=Etsi naapurustoja').first()).toBeVisible({ timeout: 5000 });
+
+    // Apply a preset to show results
+    await page.locator('text=Lapsiperheille').first().click();
+    await expect(page.locator('text=osumaa').first()).toBeVisible({ timeout: 5000 });
+
+    await expect(page).toHaveScreenshot('filter-panel-active.png', {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+
+  test('colorblind mode', async ({ page }) => {
+    await page.goto('/');
+    await waitForDataLoaded(page);
+    await waitForMapIdle(page);
+
+    // Open settings dropdown
+    const settingsButton = page.locator(`button[aria-label="${await getSettingsLabel(page)}"]`);
+    await settingsButton.click();
+
+    // Select protanopia from the colorblind dropdown
+    const cbSelect = page.locator('select').first();
+    await cbSelect.selectOption('protanopia');
+
+    // Close dropdown
+    await page.locator('.maplibregl-canvas').click({ position: { x: 10, y: 10 } });
+    await page.waitForTimeout(500);
+
+    await waitForMapIdle(page);
+
+    await expect(page).toHaveScreenshot('colorblind-protanopia.png', {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+});
+
+/** Get the settings button aria-label (varies by language). */
+async function getSettingsLabel(page: import('@playwright/test').Page): Promise<string> {
+  // Try Finnish first (default), fallback to English
+  const fiButton = page.locator('button[aria-label="Asetukset"]');
+  if (await fiButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+    return 'Asetukset';
+  }
+  return 'Settings';
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --project=e2e",
+    "test:visual": "playwright test --project=visual",
+    "test:visual:update": "playwright test --project=visual --update-snapshots",
     "build:data": "npx -p topojson-server geo2topo neighborhoods=public/data/metro_neighborhoods.geojson > src/data/metro_neighborhoods.topojson && node scripts/build_grid_data.mjs"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,34 @@ export default defineConfig({
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',
   },
+  /* Screenshot comparison settings for visual regression tests */
+  expect: {
+    toHaveScreenshot: {
+      /* Animations can cause flaky diffs — disable them for screenshots */
+      animations: 'disabled',
+      /* Ignore anti-aliasing differences across render backends */
+      threshold: 0.3,
+    },
+  },
+  projects: [
+    {
+      name: 'e2e',
+      testDir: './e2e',
+      testIgnore: ['**/visual/**'],
+      use: {
+        browserName: 'chromium',
+      },
+    },
+    {
+      name: 'visual',
+      testDir: './e2e/visual',
+      use: {
+        browserName: 'chromium',
+        /* Fixed viewport for deterministic screenshots */
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
   webServer: {
     command: 'npm run preview',
     url: 'http://localhost:4173',


### PR DESCRIPTION
## Summary

- Add Playwright screenshot comparison tests (`toHaveScreenshot()`) covering 6 key visual states: default map load, dark mode, neighborhood panel, comparison panel with 3 neighborhoods, filter panel with active preset, and colorblind mode (protanopia)
- Split Playwright config into `e2e` and `visual` projects with fixed 1280×720 viewport for deterministic screenshots
- Add CI step to run visual regression tests on PRs, with diff artifact upload on failure

## Details

**New files:**
- `e2e/visual/visual-regression.spec.ts` — 6 visual regression tests

**Modified files:**
- `playwright.config.ts` — Added `e2e` and `visual` projects, screenshot comparison settings (animations disabled, anti-aliasing threshold)
- `package.json` — Added `test:visual` and `test:visual:update` scripts
- `.github/workflows/ci.yml` — Added visual regression test step + artifact upload on failure

**Baseline generation:** Run `npm run test:visual:update` to generate/update baseline screenshots. The first CI run will need baselines committed to the repo.

## Test plan

- [ ] Run `npm run build && npm run test:visual:update` to generate baseline screenshots
- [ ] Commit baselines to `e2e/visual/visual-regression.spec.ts-snapshots/`
- [ ] Verify `npm run test:visual` passes against committed baselines
- [ ] Verify `npm run test:e2e` still runs only functional e2e tests
- [ ] Verify CI workflow runs both e2e and visual steps

https://claude.ai/code/session_01RG1qsATPq2wsiNmbMy6jjQ